### PR TITLE
ensure there is no more network before stopping the service

### DIFF
--- a/networkmanager-dispatcher-insync-systemd/10-insync
+++ b/networkmanager-dispatcher-insync-systemd/10-insync
@@ -8,6 +8,6 @@ case "$2" in
 			systemctl restart insync@"${username}"
         ;;
         down)
-			systemctl stop insync@"${username}"
+			[[ "$(nmcli n connectivity check)" == "full" ]] || systemctl stop insync@"${username}"
         ;;
 esac


### PR DESCRIPTION
When you have several networks, you can keep internet even if nm down one of the interfaces.
This is especially the case when you have both wired and wireless connections.

Note: I did not have the ability to fully check this fix, in case you cannot check it, I will make tests as soon as possible.
